### PR TITLE
Don't Call Python Explicitly

### DIFF
--- a/test/advection1d.py
+++ b/test/advection1d.py
@@ -49,7 +49,7 @@ copyfile('build.py', TMP_BUILD)
 # COMPILE CODE AT MULTIPLE RESOLUTIONS USING SEPARATE BUILD FILE
 for n,res in enumerate(RES):
   util.change_cparm('N{}TOT'.format(IDIM), res, TMP_BUILD)
-  call(['python', TMP_BUILD, '-dir', TMP_DIR, '-idim', str(IDIM)])
+  call([sys.executable, TMP_BUILD, '-dir', TMP_DIR, '-idim', str(IDIM)])
   call(['cp', os.path.join(os.getcwd(), TMP_DIR, 'bhlight'),
         '../../test/' + TMP_DIR + '/bhlight_' + str(res)])
 copyfile(os.path.join(os.getcwd(), TMP_DIR, 'param_template.dat'), '../../test/' + 

--- a/test/advection2d.py
+++ b/test/advection2d.py
@@ -71,7 +71,7 @@ for n,res in enumerate(RES):
     if MPI:
         for d in [1,2]:
             util.change_cparm('N{}CPU'.format(d), 2, TMP_BUILD)
-    call(['python', TMP_BUILD, '-dir', TMP_DIR])
+    call([sys.executable, TMP_BUILD, '-dir', TMP_DIR])
     parm_src = os.path.join(os.getcwd(), TMP_DIR, 'param_template.dat')
     parm_dest = '../../test/' +  TMP_DIR + '/param.dat'
     call(['cp', os.path.join(os.getcwd(), TMP_DIR, 'bhlight'),

--- a/test/advection3d.py
+++ b/test/advection3d.py
@@ -74,7 +74,7 @@ for n,res in enumerate(RES):
     if MPI:
         for d in [1,2,3]:
             util.change_cparm('N{}CPU'.format(d), 2, TMP_BUILD)
-    call(['python', TMP_BUILD, '-dir', TMP_DIR])
+    call([sys.executable, TMP_BUILD, '-dir', TMP_DIR])
     parm_src = os.path.join(os.getcwd(), TMP_DIR, 'param_template.dat')
     parm_dest = '../../test/' +  TMP_DIR + '/param.dat'
     call(['cp', os.path.join(os.getcwd(), TMP_DIR, 'bhlight'),

--- a/test/binning.py
+++ b/test/binning.py
@@ -32,7 +32,7 @@ else:
 os.chdir('../prob/' + PROBLEM)
 
 # COMPILE CODE
-args = ['python', 'build.py', '-dir', TMP_DIR, '-idim', str(IDIM)]
+args = [sys.executable, 'build.py', '-dir', TMP_DIR, '-idim', str(IDIM)]
 if MPI:
   args += ['-mpi']
 call(args)

--- a/test/bondi.py
+++ b/test/bondi.py
@@ -41,7 +41,7 @@ copyfile('build.py', TMP_BUILD)
 for n in xrange(len(RES)):
   util.change_cparm('N1TOT', RES[n], TMP_BUILD)
   util.change_cparm('N2TOT', RES[n], TMP_BUILD)
-  call(['python', TMP_BUILD, '-dir', TMP_DIR])
+  call([sys.executable, TMP_BUILD, '-dir', TMP_DIR])
   call(['cp', os.path.join(os.getcwd(), TMP_DIR, 'bhlight'),
         '../../test/' + TMP_DIR + '/bhlight_' + str(RES[n])])
 copyfile(os.path.join(os.getcwd(), TMP_DIR, 'param_template.dat'), '../../test/' +

--- a/test/brem.py
+++ b/test/brem.py
@@ -35,7 +35,7 @@ else:
 os.chdir('../prob/' + PROBLEM)
 
 # COMPILE CODE
-call(['python', 'build.py', '-dir', TMP_DIR])
+call([sys.executable, 'build.py', '-dir', TMP_DIR])
 os.chdir('../../test')
 call(['mv', '../prob/' + PROBLEM + '/' + TMP_DIR, './'])
 

--- a/test/brem_mpi.py
+++ b/test/brem_mpi.py
@@ -28,7 +28,7 @@ for arg in sys.argv:
 os.chdir('../prob/' + PROBLEM)
 
 # COMPILE CODE
-call(['python', 'build_mpi.py', '-dir', TMP_DIR])
+call([sys.executable, 'build_mpi.py', '-dir', TMP_DIR])
 os.chdir('../../test/')
 call(['mv', '../prob/' + PROBLEM + '/' + TMP_DIR, './'])
 

--- a/test/comptonization.py
+++ b/test/comptonization.py
@@ -31,7 +31,7 @@ else:
 os.chdir('../prob/' + PROBLEM)
 
 # COMPILE CODE
-call(['python', 'build.py', '-dir', TMP_DIR])
+call([sys.executable, 'build.py', '-dir', TMP_DIR])
 os.chdir('../../test')
 call(['mv', '../prob/' + PROBLEM + '/' + TMP_DIR, './'])
 

--- a/test/entropy.py
+++ b/test/entropy.py
@@ -29,7 +29,7 @@ PROBLEM = 'entropy'
 os.chdir('../prob/' + PROBLEM)
 
 # COMPILE CODE
-call(['python', 'build.py', '-dir', TMP_DIR])
+call([sys.executable, 'build.py', '-dir', TMP_DIR])
 os.chdir('../../test')
 call(['mv', '../prob/' + PROBLEM + '/' + TMP_DIR, './'])
 

--- a/test/fornax.py
+++ b/test/fornax.py
@@ -41,7 +41,7 @@ except ImportError:
 os.chdir('../prob/' + PROBLEM)
 
 # COMPILE CODE
-compile_args = ['python','build.py','-dir',TMP_DIR]
+compile_args = [sys.executable,'build.py','-dir',TMP_DIR]
 if MPI:
     compile_args += ['-mpi']
 if EQUIL:

--- a/test/generate_all_plots.py
+++ b/test/generate_all_plots.py
@@ -48,7 +48,7 @@ print '  COMMIT:  ' + HASH + '\n'
 
 for TEST in TESTS:
     print '  ' + util.color.BOLD + TEST + util.color.NORMAL
-    args = ['python', TEST]
+    args = [sys.executable, TEST]
     if TABLE:
         args += ['-table']
     popen = sp.Popen(args, stdout=sp.PIPE, stderr=sp.PIPE,

--- a/test/leptoneq.py
+++ b/test/leptoneq.py
@@ -38,7 +38,7 @@ except ImportError:
 os.chdir('../prob/' + PROBLEM)
 
 # COMPILE CODE
-compile_args = ['python','build.py','-dir',TMP_DIR]
+compile_args = [sys.executable,'build.py','-dir',TMP_DIR]
 if MPI:
     compile_args += ['-mpi']
 call(compile_args)

--- a/test/mhdmodes1d.py
+++ b/test/mhdmodes1d.py
@@ -40,7 +40,7 @@ copyfile('build.py', TMP_BUILD)
 for n in range(len(RES)):
   util.change_cparm('N{}TOT'.format(IDIM), RES[n], TMP_BUILD)
   #util.change_cparm('RECONSTRUCTION', 'PARA', TMP_BUILD)
-  args = ['python', TMP_BUILD, '-dir', TMP_DIR, '-idim', str(IDIM)]
+  args = [sys.executable, TMP_BUILD, '-dir', TMP_DIR, '-idim', str(IDIM)]
   if TABLE:
     args += ['-table']
   call(args)

--- a/test/mhdmodes2d.py
+++ b/test/mhdmodes2d.py
@@ -44,7 +44,7 @@ copyfile('build.py', TMP_BUILD)
 for n in range(len(RES)):
   util.change_cparm('N1TOT', RES[n], TMP_BUILD)
   util.change_cparm('N2TOT', RES[n], TMP_BUILD)
-  args = ['python', TMP_BUILD, '-dir', TMP_DIR]
+  args = [sys.executable, TMP_BUILD, '-dir', TMP_DIR]
   if TABLE:
     args.append('-table')
   call(args)

--- a/test/mhdmodes2d_mpi.py
+++ b/test/mhdmodes2d_mpi.py
@@ -41,7 +41,7 @@ copyfile('build_mpi.py', TMP_BUILD)
 for n in range(len(RES)):
   util.change_cparm('N1TOT', RES[n], TMP_BUILD)
   util.change_cparm('N2TOT', RES[n], TMP_BUILD)
-  call(['python', TMP_BUILD, '-dir', TMP_DIR])
+  call([sys.executable, TMP_BUILD, '-dir', TMP_DIR])
   call(['cp', os.path.join(os.getcwd(), TMP_DIR, 'bhlight'),
         '../../test/' + TMP_DIR + '/bhlight_' + str(RES[n])])
 copyfile(os.path.join(os.getcwd(), TMP_DIR, 'param_template.dat'), '../../test/' + 

--- a/test/mhdmodes3d.py
+++ b/test/mhdmodes3d.py
@@ -54,7 +54,7 @@ for n in range(len(RES)):
   util.change_cparm('N2CPU', nxcpu,  TMP_BUILD)
   util.change_cparm('N3CPU', nxcpu,  TMP_BUILD)
   util.change_cparm('OPENMP', 'True', TMP_BUILD)
-  args = ['python', TMP_BUILD, '-dir', TMP_DIR]
+  args = [sys.executable, TMP_BUILD, '-dir', TMP_DIR]
   if TABLE:
     args.append('-table')
   call(args)

--- a/test/multiscatt.py
+++ b/test/multiscatt.py
@@ -37,7 +37,7 @@ except ImportError:
 os.chdir('../prob/' + PROBLEM)
 
 # COMPILE CODE
-args = ['python', 'build.py', '-dir', TMP_DIR]
+args = [sys.executable, 'build.py', '-dir', TMP_DIR]
 if MPI:
   args += ['-mpi']
 if NOREBALANCE:

--- a/test/sod.py
+++ b/test/sod.py
@@ -36,7 +36,7 @@ else:
 os.chdir('../prob/' + PROBLEM)
 
 # COMPILE CODE
-args = ['python', 'build.py', '-dir', TMP_DIR]
+args = [sys.executable, 'build.py', '-dir', TMP_DIR]
 if TABLE:
   args.append('-table')
 if FORCE:

--- a/test/sod_mpi.py
+++ b/test/sod_mpi.py
@@ -27,7 +27,7 @@ for arg in sys.argv:
 os.chdir('../prob/' + PROBLEM)
 
 # COMPILE CODE
-call(['python', 'build.py', '-mpi', '-dir', TMP_DIR])
+call([sys.executable, 'build.py', '-mpi', '-dir', TMP_DIR])
 os.chdir('../../test/')
 call(['mv', '../prob/' + PROBLEM + '/' + TMP_DIR, './'])
 

--- a/test/table.py
+++ b/test/table.py
@@ -24,7 +24,7 @@ gam = 1.4
 
 os.chdir('../prob/' + PROBLEM)
 # COMPILE CODE
-args = ['python', 'build.py', '-dir', TMP_DIR]
+args = [sys.executable, 'build.py', '-dir', TMP_DIR]
 call(args)
 call(['mv', 'sc_eos_gamma_{}.h5'.format(str(gam).replace('.','p')), TMP_DIR])
 os.chdir('../../test/')

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -148,7 +148,7 @@ for TEST in TESTS:
   args = name_to_args(TEST)
   TESTNAME = args[0][:-3] if len(args) == 1 else TEST
   print('  ' + util.color.BOLD + TESTNAME + util.color.NORMAL)
-  args = ['python'] + args + ['-auto']
+  args = [sys.executable] + args + ['-auto']
   if TABLE:
     args += ['-table']
   if FAST:

--- a/test/thermalization.py
+++ b/test/thermalization.py
@@ -31,7 +31,7 @@ else:
 os.chdir('../prob/' + PROBLEM)
 
 # COMPILE CODE
-call(['python', 'build.py', '-dir', TMP_DIR])
+call([sys.executable, 'build.py', '-dir', TMP_DIR])
 os.chdir('../../test')
 call(['mv', '../prob/' + PROBLEM + '/' + TMP_DIR, './'])
 

--- a/test/thermalization_mpi.py
+++ b/test/thermalization_mpi.py
@@ -39,7 +39,7 @@ except ImportError:
 os.chdir('../prob/' + 'thermalization')
 
 # COMPILE CODE
-call(['python', 'build_mpi.py', '-dir', TMP_DIR])
+call([sys.executable, 'build_mpi.py', '-dir', TMP_DIR])
 os.chdir('../../test')
 call(['mv', '../prob/' + 'thermalization' + '/' + TMP_DIR, './'])
 

--- a/test/tracers1d.py
+++ b/test/tracers1d.py
@@ -39,7 +39,7 @@ cadv = 0.5
 os.chdir('../prob/' + PROBLEM)
 
 # COMPILE CODE
-call(['python', 'build.py', '-dir', TMP_DIR, '-idim',
+call([sys.executable, 'build.py', '-dir', TMP_DIR, '-idim',
       str(IDIM),'-ntot',str(RES),'-tracers'])
 os.chdir('../../test/')
 call(['mv', '../prob/' + PROBLEM + '/' + TMP_DIR, './'])

--- a/test/tracers3d.py
+++ b/test/tracers3d.py
@@ -37,7 +37,7 @@ if AUTO:
 os.chdir('../prob/' + PROBLEM)
 
 # COMPILE CODE
-call(['python', 'build.py', '-dir', TMP_DIR,
+call([sys.executable, 'build.py', '-dir', TMP_DIR,
       '-classic', '-nob', '-norenorm', '-tracertest'])
 os.chdir('../../test/')
 call(['mv', '../prob/' + PROBLEM + '/' + TMP_DIR, './'])

--- a/test/yedecay.py
+++ b/test/yedecay.py
@@ -40,7 +40,7 @@ except ImportError:
 os.chdir('../prob/' + PROBLEM)
 
 # COMPILE CODE
-compile_args = ['python','build.py','-dir',TMP_DIR]
+compile_args = [sys.executable,'build.py','-dir',TMP_DIR]
 if MPI:
     compile_args += ['-mpi']
 if ANTINU:


### PR DESCRIPTION
Solves issue #2 and replaces `call["python",...])` with `call([sys.executable,...])`. Issue was caught by @kinchb who found that if multiple versions of python are installed, it can cause problems.