### PR TITLE
Hdf hl fix

### DIFF
--- a/core/opac_emis_neutrino.c
+++ b/core/opac_emis_neutrino.c
@@ -10,9 +10,10 @@
 #include "constants.h"
 #include "decs.h"
 #include <hdf5.h>
-#include <hdf5_hl.h>
 
 #if RADIATION == RADTYPE_NEUTRINOS && BURROWS_OPACITIES
+
+#include <hdf5_hl.h>
 
 #ifdef __INTEL_COMPILER
 #define FORT_OPAC_CALL(name) opacity_table_module_mp_##name##_

--- a/core/opac_emis_neutrino.c
+++ b/core/opac_emis_neutrino.c
@@ -12,9 +12,7 @@
 #include <hdf5.h>
 
 #if RADIATION == RADTYPE_NEUTRINOS && BURROWS_OPACITIES
-
 #include <hdf5_hl.h>
-
 #ifdef __INTEL_COMPILER
 #define FORT_OPAC_CALL(name) opacity_table_module_mp_##name##_
 #else


### PR DESCRIPTION
Moved the "#include <hdf5_hl.h>" directive in opac_emis_neutrino.c to lie within the "#if RADIATION == RADTYPE_NEUTRINOS && BURROWS_OPACITIES" block, as its utilities are only needed in that case and not generally.