### PR TITLE
initial data solver in python written

### DIFF
--- a/script/analysis/analyze_eos.py
+++ b/script/analysis/analyze_eos.py
@@ -159,6 +159,16 @@ class Adiabat:
         self.slc = np.s_[self.ilrho_bounds[0]:self.ilrho_bounds[1]]
         self.lrho = self.bnd1d(eos['lrho'])
 
+    @classmethod
+    def get_if_valid(cls, s, Ye, eos):
+        try:
+            adiabat = cls(s, Ye, eos)
+        except:
+            raise ValueError("Invalid Adiabat")
+        if not adiabat.is_valid():
+            raise ValueError("Invalid Adiabat")
+        return adiabat
+
     def bnd1d(self,var):
         return var[self.slc]
 
@@ -202,6 +212,17 @@ class Adiabat:
                float(dPdrhoe_interp(lP.min())),
                float(hm1interp(lP.min()))]
         return out
+
+    def is_valid(self):
+        return np.all(np.gradient(self.project(self.eos['lT'])) >= 0)
+
+    def get_rho_of_hm1_interp(self):
+        rho_grid = self.project(self.eos['rho'])
+        hm1_grid = self.project(self.eos['hm1'])
+        fill_value = (0, self.project(self.eos['rho']).max())
+        return interpolate.interp1d(hm1_grid,rho_grid,
+                                    bounds_error = False,
+                                    fill_value=fill_value)
     
     def __call__(self,var):
         return self.project(var)

--- a/script/analysis/torus_id.py
+++ b/script/analysis/torus_id.py
@@ -107,7 +107,7 @@ def get_tot_mass(M, a, rin, rmax, eos, get_max = False):
     Returns mass in solar masses."""
     NX1 = 512
     NX2 = 512
-    X1 = np.linspace(np.log(rin),np.log(1e3), NX1)
+    X1 = np.linspace(np.log(rin),np.log(max(1e3,2*rmax)), NX1)
     rgrid = np.exp(X1)
     thgrid = np.linspace(0, np.pi/2, NX2)
     RGRID,THGRID = np.meshgrid(rgrid,thgrid,indexing='ij')

--- a/script/analysis/torus_id.py
+++ b/script/analysis/torus_id.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python
+
+# ======================================================================
+# copyright 2020. Triad National Security, LLC. All rights
+# reserved. This program was produced under U.S. Government contract
+# 89233218CNA000001 for Los Alamos National Laboratory (LANL), which is
+# operated by Triad National Security, LLC for the U.S. Department of
+# Energy/National Nuclear Security Administration. All rights in the program are
+# reserved by Triad National Security, LLC, and the U.S. Department of
+# Energy/National Nuclear Security Administration. The Government is granted
+# for itself and others acting on its behalf a nonexclusive, paid-up, irrevocable
+# worldwide license in this material to reproduce, prepare derivative works,
+# distribute copies to the public, perform publicly and display publicly, and to
+# permit others to do so.
+# ======================================================================
+
+"""Computes initial conditions for the Fishbone-Moncrief torus given a
+a black hole mass and spin, an equation of state, and a desired disk
+mass."""
+
+from units import cgs
+import numpy as np
+import scipy as sp
+from scipy import integrate, optimize
+
+def r_isco(a):
+    "Get the radius of the innermost stable circular orbit"
+    # Assumes G = c = M = 1
+    Z1 = 1 + (1-a*a)**(1./3.) * ((1 + a)**(1./3.) + (1 - a)**(1./3.))
+    Z2 = np.sqrt(3*a*a + Z1*Z1)
+    return 3 + Z2 - np.sign(a)*np.sqrt((3-Z1)*(3+Z1+2*Z2))
+
+def lfish(a, r):
+    """Get the specific angular momentum
+    from Fishbone and Moncrief, 1976."""
+    from numpy import sqrt
+    try:
+        return (
+      ((pow(a, 2) - 2. * a * sqrt(r) + pow(r, 2)) *
+          ((-2. * a * r * (pow(a, 2) - 2. * a * sqrt(r) + pow(r, 2))) /
+                  sqrt(2. * a * sqrt(r) + (-3. + r) * r) +
+              ((a + (-2. + r) * sqrt(r)) * (pow(r, 3) + pow(a, 2) * (2. + r))) /
+                  sqrt(1 + (2. * a) / pow(r, 1.5) - 3. / r))) /
+      (pow(r, 3) * sqrt(2. * a * sqrt(r) + (-3. + r) * r) *
+          (pow(a, 2) + (-2. + r) * r)))
+    except: 
+        return 0
+
+def get_lnh(a, rin, rmax, r, th):
+    """Get the log of the specific enthalpy 
+    from Fishbone, Moncrief, 1976."""
+    # Assumes G = c = M = 1
+    from numpy import log, sqrt
+    
+    l = lfish(a, rmax)
+    sth = np.sin(th)
+    cth = np.cos(th)
+    
+    DD = r * r - 2. * r + a * a
+    AA = ((r * r + a * a) * (r * r + a * a) - DD * a * a * sth * sth)
+    SS = r * r + a * a * cth * cth
+    
+    thin = np.pi/2.
+    sthin = np.sin(thin)
+    cthin = np.cos(thin)
+    DDin  = rin * rin - 2. * rin + a * a;
+    AAin  = ((rin * rin + a * a) * (rin * rin + a * a) 
+             - DDin * a * a * sthin * sthin)
+    SSin  = rin * rin + a * a * cthin * cthin
+    
+    try:
+        return (0.5 * log((1. + sqrt(1. + 4. * (l * l * SS * SS) * DD /
+                                        (AA * sth * AA * sth))) /
+                    (SS * DD / AA)) -
+          0.5 * sqrt(1. + 4. * (l * l * SS * SS) * DD / (AA * AA * sth * sth)) -
+          2. * a * r * l / AA -
+          (0.5 * log((1. + sqrt(1. + 4. * (l * l * SSin * SSin) * DDin /
+                                         (AAin * AAin * sthin * sthin))) /
+                     (SSin * DDin / AAin)) -
+              0.5 * sqrt(1. + 4. * (l * l * SSin * SSin) * DDin /
+                                  (AAin * AAin * sthin * sthin)) -
+              2. * a * rin * l / AAin))
+    except:
+        return 0
+
+def rho_from_hm1_ideal(hm1):
+    "Dummy EOS call"
+    kappa = 2e-7
+    gam = 4./3.
+    rho = pow(hm1 * (gam - 1.) / (kappa * gam), 1. / (gam - 1.))
+    return rho
+
+def compute_rho_from_coords(a, rin, rmax, eos, r, th):
+    "Get the density from Fishbone, Moncrief, 1976."
+    lnh = get_lnh(a, rin, rmax, r, th)
+    if type(lnh) == np.ndarray:
+        lnh[np.isnan(lnh)] = 0.
+        lnh[r <= rin] = 0.
+        lnh[lnh <= 0] = 0.
+    elif np.isnan(lnh) or r <= rin or lnh <= 0:
+        lnh = 0.
+    hm1 = np.exp(lnh) - 1
+    return eos(hm1)
+
+def get_tot_mass(M, a, rin, rmax, eos, get_max = False):
+    """Integrate the mass in a fishbone-moncrief disk.
+    Returns mass in solar masses."""
+    NX1 = 512
+    NX2 = 512
+    X1 = np.linspace(np.log(rin),np.log(1e3), NX1)
+    rgrid = np.exp(X1)
+    thgrid = np.linspace(0, np.pi/2, NX2)
+    RGRID,THGRID = np.meshgrid(rgrid,thgrid,indexing='ij')
+    integrand = compute_rho_from_coords(a, rin, rmax, eos,
+                                        RGRID, THGRID)
+
+    # Normalization procedure
+    rhomax = integrand.max()
+    RHO_unit = rhomax
+    L_unit = M*cgs['GNEWT']*cgs['MSOLAR']/(cgs['CL']**2)
+    M_unit = RHO_unit*(L_unit**3)
+    
+    integrand *= RGRID*RGRID*np.sin(THGRID)
+    integrand /= RHO_unit
+    tot = 2*np.pi*2.*integrate.simpson(integrate.simpson(integrand,
+                                               x=thgrid,axis=1),
+                                       x = rgrid)
+    tot *= M_unit/cgs['MSOLAR']
+    if get_max:
+        return RHO_unit, tot
+    else:
+        return tot
+
+def solve_for_rmax_rho_unit(M, a, rin, eos, md_target):
+    """Given black hole mass, spin, inner disk radius,
+    solve for rmax needed to produce a given disk mass.
+    Also returns the peak density in the disk."""
+    f = lambda rmax: get_tot_mass(M, a, rin, rmax, eos, False) - md_target
+    sol = optimize.root_scalar(f, x0 = 6, bracket = [rin, 100])
+    if not sol.converged:
+        print("Failure to converge! Solution object:")
+        print(sol)
+        raise ValueError("Convergence Failure")
+    rmax = sol.root
+    rho_max, md_measured = get_tot_mass(M, a, rin, rmax, eos, True)
+    return md_measured, sol.root, rho_max
+
+def solve_for_rmax_rho_unit_ideal_gas(M, a, md_target, rin_fac = 1.5):
+    """Sets rin = rin_fac*r_isco. Uses ideal gas."""    
+    eos = rho_from_hm1_ideal
+    rin = rin_fac*r_isco(a)
+    md_measured, rmax, rho_unit = solve_for_rmax_rho_unit(M, a, rin, eos,
+                                                          md_target)
+    L_unit = M*cgs['GNEWT']*cgs['MSOLAR']/(cgs['CL']**2)
+    m_unit = rho_unit*(L*unit**3)
+    return md_measured, rin, rmax, rho_unit, m_unit
+
+def solve_for_rmax_rho_unit_tabulated(M, a, md_target, filepath, s, ye,
+                                      rin_fac = 1.5):
+    """Sets rin = rin_fac*r_isco. Uses tabulated EOS
+    Inputs:
+    - M = mass of black hole, in solar masses
+    - a = spin of the black hole
+    - md_target = target mass of the disk, in solar masses
+    - filepath = path to EOS hdf5 file in stelllar collapse format
+    - s = entropy of the disk, in kb/baryon
+    - ye = electron fraction of the disk
+    - rin_fac = rin / r_isco. Recommended minimum value is 1.5
+
+    Outputs:
+    - md_measured = disk mass measured, in solar masses
+    - rmax = The radius of maximum pressure in the disk, in rg
+    - RHO_unit = The code unit for density required for
+                 the maximum density in the disk to be unity
+    - M_unit = The code unit for mass required for
+               the maximum density in the disk to be unit
+
+    Failure case:
+    - If the equation of state has an invalid isoentropic curve at this radius,
+      this function will raise an "Invalid Adiabat" error.
+    """
+    import analyze_eos
+    eos_obj = analyze_eos.load_eos(filepath)
+    adiabat = analyze_eos.Adiabat.get_if_valid(s, ye, eos_obj)
+    eos = adiabat.get_rho_of_hm1_interp()
+    rin = rin_fac*r_isco(a)
+    md_measured, rmax, rho_unit =  solve_for_rmax_rho_unit(M, a, rin, eos,
+                                                           md_target)
+    L_unit = M*cgs['GNEWT']*cgs['MSOLAR']/(cgs['CL']**2)
+    m_unit = rho_unit*(L_unit**3)
+    return md_measured, rin, rmax, rho_unit, m_unit
+
+if __name__ == "__main__":
+    from argparse import ArgumentParser
+    parser = ArgumentParser(
+        description=('Compute the values required for a Fishbone-Moncrief torus'
+                     + ' around a black hole.'))
+    parser.add_argument('M', type=float,
+                        help='Mass of the black hole in solar masses')
+    parser.add_argument('a', type=float,
+                        help='Spin of the black hole in solar masses')
+    parser.add_argument('md', type=float,
+                        help='Target mass in the disk in solar masses')
+    parser.add_argument('-f','--file',type=str,default=None,
+                        help=('Path to stellar collapse file for EOS.'
+                              + ' If none, defaults to ideal gas.'))
+    parser.add_argument('-s','--entropy',type=float,default=4,
+                        help='Entropy in the disk, in kb/baryon. Default is 4.')
+    parser.add_argument('-Ye','--electronfraction',type=float,default=0.1,
+                        help='Electron fraction in the disk. Default is 0.1.')
+    parser.add_argument('-r','--rinfac',type=float,default=1.5,
+                        help=('ratio ofinner radius of the disk'
+                              + ' to radius of innermost stable circular orbit.'
+                              + ' Defaults to 1.5.'))
+    args = parser.parse_args()
+    if args.file is None:
+        print("Computing initial conditions for ideal gas...")
+        md_measured, rin, rmax, rho_unit, m_unit \
+            = solve_for_rmax_rho_unit_ideal_gas(args.M,
+                                                args.a,
+                                                args.md,
+                                                args.rinfac)
+    else:
+        print("Computing initial conditions for tabulated eos...")
+        md_measured, rin, rmax, rho_unit, m_unit \
+            = solve_for_rmax_rho_unit_tabulated(args.M,
+                                                args.a,
+                                                args.md,
+                                                args.file,
+                                                args.entropy,
+                                                args.electronfraction,
+                                                args.rinfac)
+    print(("\tmd_measured = {} solar masses\n"
+           + "\terror       = {:e}\n"
+           + "\trin         = {:f} rg\n"
+           + "\trmax        = {:f} rg\n"
+           + "\tRHO_unit    = {:e} g/cm^3\n"
+           + "\tM_unit      = {:e} g\n").format(md_measured,
+                                                md_measured-args.md,
+                                                rin,
+                                                rmax,
+                                                rho_unit,
+                                                m_unit))
+


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add new charged-current neutrino interactions.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

In this pull request I  implement a new little Python script to compute the Fishbone-Moncrief prameters from relevant parameters from merger simulations. Given  a black hole mass and spin, and a disk mass, entropy, and electron fraction, and an equation of state, it computes `rin`, `rmax`, `RHO_unit`, and `M_unit`.

Some example calls might look like this:
```bash
(base) jonahm@ubuntu:$ ./torus_id.py -h
usage: torus_id.py [-h] [-f FILE] [-s ENTROPY] [-Ye ELECTRON_FRACTION]
                   [-r RINFAC]
                   M a md

Compute the values required for a Fishbone-Moncrief torus around a black hole.

positional arguments:
  M                     Mass of the black hole in solar masses
  a                     Spin of the black hole in solar masses
  md                    Target mass in the disk in solar masses

optional arguments:
  -h, --help            show this help message and exit
  -f FILE, --file FILE  Path to stellar collapse file for EOS. If none,
                        defaults to ideal gas.
  -s ENTROPY, --entropy ENTROPY
                        Entropy in the disk, in kb/baryon. Default is 4.
  -Ye ELECTRON_FRACTION, --electron-fraction ELECTRON_FRACTION
                        Electron fraction in the disk. Default is 0.1.
  -r RINFAC, --rinfac RINFAC
                        ratio ofinner radius of the disk to radius of
                        innermost stable circular orbit. Defaults to 1.5.
```

or this

```bash
(base) jonahm@ubuntu:$ ./torus_id.py 2.58 0.8 0.12 -f ../../data/Hempel_SFHoEOS_rho222_temp180_ye60_version_1.1_20120817.h5 -s 4 -Ye 0.1
Computing initial conditions for tabulated eos...
/mnt/hgfs/jonahm/programming/nubhlight/script/analysis/analyze_eos.py:94: H5pyDeprecationWarning: dataset.value has been deprecated. Use dataset[()] instead.
  eos[k] = v.value
./torus_id.py:76: RuntimeWarning: divide by zero encountered in true_divide
  2. * a * r * l / AA -
./torus_id.py:76: RuntimeWarning: invalid value encountered in subtract
  2. * a * r * l / AA -
	md_measured = 0.11999999999998444 solar masses
	error       = -1.555700e-14
	rin         = 4.359966 rg
	rmax        = 10.361335 rg
	RHO_unit    = 1.140525e+12 g/cm^3
	M_unit      = 6.311632e+28 g
```

You can also import this capability into your own python script like this:
```python
from torus_id import solve_for_rmax_rho_unit_tabulated
md_measured, rin, rmax, rho_unit, m_unit = solve_for_rmax_rho_unit_tabulated(M, a, md, eospath, s, ye)
```

I also made some minor changes to my `analyze_eos` script which makes it a bit more robust and allows us to compute `rho(hm1)` for a tabulated eos in Python.

## Future Work

- I didn't integrate this with `prob/torus_cbc/build.py` so that this could be automatically called at build time. I will add that capability later if desired.
- Some entropies in an EOS file look like they produce problematic constant entropy curves that the root finder may not be able to capture accurately and robustly. This could be fixed by perhaps massaging the table. For now, though, I throw an error.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->


