### PR TITLE
Fix segfault on restart read

### DIFF
--- a/core/io.c
+++ b/core/io.c
@@ -1519,6 +1519,7 @@ void restart_read(char *fname) {
       nph_in += dset_sizes[n];
     }
     H5Sclose(space);
+    H5Dclose(ph_dsets[n]);
   }
   printf("[%i] nph_in = %lu\n", mpi_myrank(), (unsigned long int)nph_in);
   // Actually read datasets
@@ -1527,8 +1528,11 @@ void restart_read(char *fname) {
     int noffset = 0;
     for (int n = 0; n < num_datasets; n++) {
       if (n % mpi_nprocs() == mpi_myrank()) {
+        sprintf(dsetnam, "photons_%08d", n);
+        ph_dsets[n] = H5Dopen(file_id, dsetnam, H5P_DEFAULT);
         H5Dread(ph_dsets[n], phmemtype, H5S_ALL, H5S_ALL, H5P_DEFAULT,
             &rdata[noffset]);
+        H5Dclose(ph_dsets[n]);
         noffset += dset_sizes[n];
       }
     }
@@ -1573,9 +1577,6 @@ void restart_read(char *fname) {
   }
 
   free(rdata);
-  for (int n = 0; n < num_datasets; n++) {
-    H5Dclose(ph_dsets[n]);
-  }
   free(ph_dsets);
   free(dset_sizes);
 #endif // RADIATION

--- a/script/machine/debian.py
+++ b/script/machine/debian.py
@@ -39,7 +39,8 @@ def get_options():
   host = {}
 
   host['NAME']           = os.uname()[1]
-  host['COMPILER']       = '/usr/local/hdf5-parallel/bin/h5pcc'
+  #host['COMPILER']       = '/usr/local/hdf5-parallel/bin/h5pcc'
+  host['COMPILER']       = 'h5pcc'
   host['COMPILER_FLAGS'] = flags_base + ' ' + fcflags + ' ' + '-O2 -march=native'
   host['DEBUG_FLAGS']    = flags_base + ' ' + fcflags + ' ' + '-g -O0'
   host['GSL_DIR']        = ''


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add new charged-current neutrino interactions.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

I can't immediately deduce whether `H5DOpen` creates the entire dataset in RAM when called, but this PR closes each processor's dataset right after it is used which should solve the issue if this is indeed the problem. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.

