### PR TITLE
hdf5 restart single dset

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-nubhlight-1.3
+nubhlight-1.4

--- a/core/coord.c
+++ b/core/coord.c
@@ -37,7 +37,7 @@
  *
  */
 
-void coord(int i, int j, int k, int loc, double *X) {
+void coord(int i, int j, int k, int loc, double X[NDIM]) {
   X[0] = t;
 
   i += global_start[1];
@@ -488,14 +488,14 @@ void set_grid() {
             0.) {
           double cplus      = fabs((-ggeom[i][j][CENT].gcon[0][mu] +
                                   sqrt(pow(ggeom[i][j][CENT].gcon[0][mu], 2.) -
-                                       ggeom[i][j][CENT].gcon[mu][mu] *
-                                           ggeom[i][j][CENT].gcon[0][0])) /
-                              (ggeom[i][j][CENT].gcon[0][0]));
+                                            ggeom[i][j][CENT].gcon[mu][mu] *
+                                                ggeom[i][j][CENT].gcon[0][0])) /
+                                   (ggeom[i][j][CENT].gcon[0][0]));
           double cminus     = fabs((-ggeom[i][j][CENT].gcon[0][mu] -
                                    sqrt(pow(ggeom[i][j][CENT].gcon[0][mu], 2.) -
-                                        ggeom[i][j][CENT].gcon[mu][mu] *
-                                            ggeom[i][j][CENT].gcon[0][0])) /
-                               (ggeom[i][j][CENT].gcon[0][0]));
+                                            ggeom[i][j][CENT].gcon[mu][mu] *
+                                                ggeom[i][j][CENT].gcon[0][0])) /
+                                   (ggeom[i][j][CENT].gcon[0][0]));
           light_phase_speed = MY_MAX(cplus, cminus);
         } else {
           light_phase_speed = SMALL;

--- a/core/current.c
+++ b/core/current.c
@@ -134,7 +134,7 @@ int antisym(int a, int b, int c, int d) {
 }
 
 // Due to Norm Hardy; good for general n
-int pp(int n, int P[n]) {
+int pp(int n, int *P) {
   int x;
   int p = 0;
   int v[n];

--- a/script/analysis/restart_flatten_particles.py
+++ b/script/analysis/restart_flatten_particles.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+######################################################################
+# Flattens particle dataset in restart file to new format
+######################################################################
+
+from __future__ import print_function,division
+import h5py
+import numpy as np
+from argparse import ArgumentParser
+
+def get_dsets_and_sizes(h5file):
+    """gets photon datasets and sizes"""
+    keys = []
+    sizes = []
+    for k,v in h5file.items():
+        if 'photons_' in k:
+            keys.append(k)
+            sizes.append(v.shape[0])
+    return keys,sizes
+
+def update_file(h5file):
+    "Updates hdf5 file object"
+    keys,sizes = get_dsets_and_sizes(h5file)
+    if len(keys) <= 0:
+        raise ValueError("This file does not need conversion.")
+    sizes = np.array(sizes)
+    offsets = np.cumsum(sizes)
+    h5file.create_dataset('particle_counts',
+                          data=sizes)
+    h5file.create_dataset('particle_offsets',
+                          data=offsets)
+    data = list([None for k in keys])
+    for i,k in enumerate(keys):
+        print("\tReading dataset",
+              k,"with size",
+              h5file[k].shape)
+        data[i] = h5file[k][:]
+    data = np.hstack(data)
+    h5file.create_dataset('superphotons',
+                          data=data)
+
+if __name__ == "__main__":
+    parser = ArgumentParser("Flatten a particle dataset in a restart file to new restart format")
+    parser.add_argument('restart', type=str,
+                        help="Restart file to flatten")
+    args = parser.parse_args()
+    print("Updating file",args.restart)
+    with h5py.File(args.restart, 'r+') as f:
+        update_file(f)

--- a/script/analysis/restart_flatten_particles.py
+++ b/script/analysis/restart_flatten_particles.py
@@ -24,7 +24,9 @@ def update_file(h5file):
     if len(keys) <= 0:
         raise ValueError("This file does not need conversion.")
     sizes = np.array(sizes)
-    offsets = np.cumsum(sizes)
+    offsets = np.zeros(len(sizes)+1)
+    offsets[1:] = np.cumsum(sizes)
+    offsets = offsets[:-1]
     h5file.create_dataset('particle_counts',
                           data=sizes)
     h5file.create_dataset('particle_offsets',
@@ -36,6 +38,7 @@ def update_file(h5file):
               h5file[k].shape)
         data[i] = h5file[k][:]
     data = np.hstack(data)
+    print("\tWriting superphoton dataset.")
     h5file.create_dataset('superphotons',
                           data=data)
 
@@ -47,3 +50,4 @@ if __name__ == "__main__":
     print("Updating file",args.restart)
     with h5py.File(args.restart, 'r+') as f:
         update_file(f)
+    print("Done.")


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add new charged-current neutrino interactions.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Motivated by the failure of the code to restart for large particle datasets at scale, I try a full rewrite of the particle restart machinery. Instead of splitting the particles into 1 HDF5 dataset per MPI rank, I use a single dataset, but also record the number of particles per MPI rank so that the dataset can be re-read with parall-hdf5 using hyperslabs the same way the grid is.

While I was at it, I also removed some warnings.

I also add a script in the analysis directory which can convert an old-style restart file to a new style. (Warning it runs in serial and uses a lot of memory. Should be used thoughtfully on a big computer.)

Tested on my desktop but not at scale.

This is a big enough change that I bumped nubhlight's version number.

@brryan can you sanity check me? Is this reasonable?

@kelslund can you try converting a restart file to this new format and trying to restart from it with the new I/O code?

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.

