### PR TITLE
fix oscillation probability and add histograms for particle origin

### DIFF
--- a/core/decs.h
+++ b/core/decs.h
@@ -316,6 +316,9 @@ typedef double grid_tensor_type[N1 + 2 * NG][N2 + 2 * NG][N3 + 2 * NG][NDIM]
 typedef int    grid_int_type[N1 + 2 * NG][N2 + 2 * NG][N3 + 2 * NG];
 typedef double grid_eosvar_type[N1 + 2 * NG][N2 + 2 * NG][N3 + 2 * NG]
                                [EOS_NUM_EXTRA];
+#if RZ_HISTOGRAMS
+typedef double rz_hist_type[RZ_HISTOGRAMS_N];
+#endif // RZ_HISTOGRAMS
 typedef void (*passive_init_ftype)(int, int, int, double *, double *);
 typedef double (*hc_ftype)(double, double);
 
@@ -337,6 +340,12 @@ extern grid_radg_type   radG_buf; // ...buffer for communication
 extern grid_tensor_type Rmunu;    // Radiation stress-energy tensor
 extern grid_int_type    Nsph;
 extern grid_double_type nph;
+#if RZ_HISTOGRAMS
+extern rz_hist_type rz_r_orig_hist, rz_z_orig_hist;
+#if NEUTRINO_OSCILLATIONS
+extern rz_hist_type osc_rz_r_orig_hist, osc_rz_z_orig_hist;
+#endif // NEUTRINO_OSCILLATIONS
+#endif // RZ_HISTOGRAMS
 
 extern struct of_photon **photon_lists;
 extern struct of_photon **photon_mpi_lists;
@@ -492,6 +501,9 @@ extern double cnu_flat;
 #if MULTISCATT_TEST
 extern double ms_theta_nu0, ms_delta0;
 #endif // MULTISCATT_TEST
+#if RZ_HISTOGRAMS
+extern double rz_rmax, rz_zmax, delta_rcyl, delta_z;
+#endif // RZ_HISTOGRAMS
 #endif // RADIATION
 #if ELECTRONS
 extern double tptemin, tptemax;
@@ -575,10 +587,12 @@ struct of_photon {
   int               origin[NDIM];
   double            t0;
   int               is_tracked;
+  // Only relevant for neutrino oscillations
+  int               has_oscillated;
   struct of_photon *next;
 };
 
-#define PH_ELEM (11)
+#define PH_ELEM (12)
 struct of_track_photon {
   double X1;
   double X2;
@@ -769,7 +783,10 @@ void report_load_imbalance();
 void print_rad_types();
 void count_leptons(grid_prim_type P, double dt, int nstep);
 #endif
-#endif
+#if RZ_HISTOGRAMS
+void generate_rz_histograms();
+#endif // RZ_HISTOGRAMS
+#endif // RADIATION
 
 // electrons.c
 #if ELECTRONS

--- a/core/defs.h
+++ b/core/defs.h
@@ -27,6 +27,13 @@ grid_radg_type     radG_buf; // ...buffer for communication
 grid_tensor_type   Rmunu;
 grid_int_type      Nsph;
 grid_double_type   nph;
+#if RZ_HISTOGRAMS
+rz_hist_type rz_r_orig_hist, rz_z_orig_hist;
+#if NEUTRINO_OSCILLATIONS
+rz_hist_type osc_rz_r_orig_hist, osc_rz_z_orig_hist;
+#endif // NEUTRINO_OSCILLATIONS
+#endif // RZ_HISTOGRAMS
+
 struct of_photon **photon_lists;
 struct of_photon **photon_mpi_lists;
 
@@ -164,6 +171,9 @@ double cnu_flat;
 #if MULTISCATT_TEST
 double ms_theta_nu0, ms_delta0;
 #endif // MULTISCATT_TEST
+#if RZ_HISTOGRAMS
+double rz_rmax, rz_zmax, delta_rcyl, delta_z;
+#endif // RZ_HISTOGRAMS
 #endif // RADIATION
 #if ELECTRONS
 double tptemin, tptemax;

--- a/core/input.c
+++ b/core/input.c
@@ -146,6 +146,10 @@ void set_core_params() {
   set_param("ms_theta_nu0", &ms_theta_nu0);
   set_param("ms_delta0", &ms_delta0);
 #endif // MULTISCATT_TEST
+#if RZ_HISTOGRAMS
+  set_param("rz_rmax", &rz_rmax);
+  set_param("rz_zmax", &rz_zmax);
+#endif // RZ_HISTOGRAMS
 #if (RADIATION == RADTYPE_NEUTRINOS)
 #if BURROWS_OPACITIES
   set_param("opac_param_file", &opac_param_file);
@@ -242,4 +246,9 @@ void init_params(char *pfname) {
   set_core_params();
   set_problem_params();
   read_params(pfname);
+  // TODO: Not the best place for this?
+#if RZ_HISTOGRAMS
+  delta_rcyl = rz_rmax / RZ_HISTOGRAMS_N;
+  delta_z = rz_zmax / RZ_HISTOGRAMS_N;
+#endif // RZ_HISTOGRAMS
 }

--- a/core/interact.c
+++ b/core/interact.c
@@ -603,6 +603,7 @@ memcpy((void*)(&m), (void*)(&(m_grd[i][j][k])),
           phscatt->origin[1] = i;
           phscatt->origin[2] = j;
           phscatt->origin[3] = k;
+          phscatt->has_oscillated = ph->has_oscillated;
 
           double wsave = ph->w;
           ph->w        = (1. - 1. / bias_scatt[scatt_to_do]) * ph->w;

--- a/core/make_superphotons.c
+++ b/core/make_superphotons.c
@@ -275,6 +275,7 @@ void sample_photon(int i, int j, int k, double t, double dt, int type,
     } else {
       tmp[n]->is_tracked = 0;
     }
+    tmp[n]->has_oscillated = 0;
   }
 }
 

--- a/core/mpi.c
+++ b/core/mpi.c
@@ -184,7 +184,7 @@ void init_mpi() {
       MPI_DOUBLE, MPI_INT, MPI_INT, MPI_INT, MPI_DOUBLE, MPI_INT, MPI_INT,
       mpi_pointer_type};
   int          blocklen[PH_ELEM] = {
-      NDIM * NSUP, NDIM * NSUP, NDIM * NSUP, 1, 1, 1, 1, NDIM, 1, 1, 1};
+      NDIM * NSUP, NDIM * NSUP, NDIM * NSUP, 1, 1, 1, 1, NDIM, 1, 1, 1, 1};
   MPI_Aint         disp[PH_ELEM];
   struct of_photon tmp;
   MPI_Get_address(&(tmp.X[0][0]), &(disp[0]));

--- a/core/mpi.c
+++ b/core/mpi.c
@@ -181,7 +181,7 @@ void init_mpi() {
   MPI_Type_contiguous(sizeof(struct of_photon *), MPI_BYTE, &mpi_pointer_type);
   MPI_Type_commit(&mpi_pointer_type);
   MPI_Datatype type[PH_ELEM] = {MPI_DOUBLE, MPI_DOUBLE, MPI_DOUBLE, MPI_DOUBLE,
-      MPI_DOUBLE, MPI_INT, MPI_INT, MPI_INT, MPI_DOUBLE, MPI_INT,
+      MPI_DOUBLE, MPI_INT, MPI_INT, MPI_INT, MPI_DOUBLE, MPI_INT, MPI_INT,
       mpi_pointer_type};
   int          blocklen[PH_ELEM] = {
       NDIM * NSUP, NDIM * NSUP, NDIM * NSUP, 1, 1, 1, 1, NDIM, 1, 1, 1};
@@ -197,7 +197,8 @@ void init_mpi() {
   MPI_Get_address(tmp.origin, &(disp[7]));
   MPI_Get_address(&(tmp.t0), &(disp[8]));
   MPI_Get_address(&(tmp.is_tracked), &(disp[9]));
-  MPI_Get_address(&(tmp.next), &(disp[10]));
+  MPI_Get_address(&(tmp.has_oscillated), &(disp[10]));
+  MPI_Get_address(&(tmp.next), &(disp[11]));
   MPI_Aint base;
   MPI_Get_address(&tmp, &base);
   for (int n = 0; n < PH_ELEM; n++) {

--- a/core/oscillations.c
+++ b/core/oscillations.c
@@ -232,6 +232,7 @@ void oscillate(grid_local_moment_type local_moments, grid_Gnu_type gnu) {
             // adding 2 on ring 0, 1, 2, 3
             // moves through without changing to antiparticle.
             ph->type = (ph->type + (RAD_NUM_TYPES / 2)) % RAD_NUM_TYPES;
+            ph->has_oscillated = 1;
 
             #pragma omp atomic
             local_osc_count[ix1][ix2] += ph->w;

--- a/core/oscillations.c
+++ b/core/oscillations.c
@@ -223,7 +223,7 @@ void oscillate(grid_local_moment_type local_moments, grid_Gnu_type gnu) {
           double p_survival = peq;
 #else
           double p_survival =
-              in_shallow ? peq : (1 - (1 - peq) * B / (A + SMALL));
+              in_shallow ? peq : (1 - (1 - peq) * shallow / (deep + SMALL));
 #endif // FORCE_EQUIPARTITION
           double p_osc = 1. - p_survival;
           if (get_rand() < p_osc) {

--- a/core/oscillations.c
+++ b/core/oscillations.c
@@ -143,12 +143,8 @@ void compute_local_gnu(grid_local_angles_type f, grid_Gnu_type local_Ns,
       const double XLN =
           (f[b][i][j][NU_HEAVY][imu] - f[b][i][j][ANTINU_HEAVY][imu]);
 
-      double   tot = 0;
-      TYPELOOP tot += f[b][i][j][itp][imu];
-      double   ebar = tot / (stddev + SMALL);
-
       double g_temp     = ELN - 0.5 * XLN;
-      gnu[b][i][j][imu] = (fabs(g_temp) > ebar) * g_temp;
+      gnu[b][i][j][imu] = (fabs(g_temp) > stddev) * g_temp;
     }
   }
 }
@@ -216,7 +212,6 @@ void oscillate(grid_local_moment_type local_moments, grid_Gnu_type gnu) {
           int g_in_B = G > 0;
 
           int in_shallow = (A_is_shallow && g_in_A) || (B_is_shallow && g_in_B);
-          int in_deep    = !(in_shallow);
 
           double peq = nu_is_heavy(ph->type) ? (2./3.) : (1./3.);
 #if FORCE_EQUIPARTITION

--- a/prob/oscillations/build.py
+++ b/prob/oscillations/build.py
@@ -131,6 +131,7 @@ bhl.config.set_cparm('LOCAL_ANGLES_NX2', NTOT)
 bhl.config.set_cparm('RAD_NUM_TYPES', 4)
 bhl.config.set_cparm('NEUTRINO_OSCILLATIONS', True)
 bhl.config.set_cparm('FORCE_EQUIPARTITION', False)
+bhl.config.set_cparm("RZ_HISTOGRAMS", True)
 
                            ### RUNTIME PARAMETERS ###
 

--- a/prob/torus_cbc/build.py
+++ b/prob/torus_cbc/build.py
@@ -470,6 +470,8 @@ if RADIATION:
     bhl.config.set_rparm('numin', 'double', default = NUMIN)
     bhl.config.set_rparm('numax', 'double', default = NUMAX)
     bhl.config.set_rparm('nph_per_proc', 'double', default = NPH_PER_PROC)
+    bhl.config.set_rparm('rz_rmax', 'double', default = Rout_rad)
+    bhl.config.set_rparm('rz_zmax', 'double', default = Rout_rad)
 
 if TRACERS:
     bhl.config.set_rparm('ntracers', 'int', default = NTCR_TOT)

--- a/prob/torus_cbc/build.py
+++ b/prob/torus_cbc/build.py
@@ -423,6 +423,7 @@ bhl.config.set_cparm('X2R_RAD_BOUND', 'BC_ESCAPE')
 bhl.config.set_cparm('X3L_RAD_BOUND', 'BC_PERIODIC')
 bhl.config.set_cparm('X3R_RAD_BOUND', 'BC_PERIODIC')
 bhl.config.set_cparm('DIAGNOSTICS_USE_RADTYPES', True)
+bhl.config.set_cparm('RZ_HISTOGRAMS', True)
 # bhl.config.set_cparm('RECORD_DT_MIN', True)
 
 if OSCILLATIONS:

--- a/script/config.py
+++ b/script/config.py
@@ -354,6 +354,13 @@ def build(PROBLEM, PATHS):
     else:
       set_cparm('NEUTRINO_OSCILLATIONS', 0)
       set_cparm('FORCE_EQUIPARTITION', 0)
+    if util.parm_is_active(CPARMS, "RZ_HISTOGRAMS"):
+      print_config("RZ_HISTOGRAMS", CPARMS["RZ_HISTOGRAMS"])
+      if not util.parm_is_active(CPARMS, "RZ_HISTOGRAMS_N"):
+        set_cparm("RZ_HISTOGRAMS_N", 32)
+      print_config("RZ_HISTOGRAMS_N", CPARMS["RZ_HISTOGRAMS_N"])
+    else:
+      set_cparm("RZ_HISTOGRAMS", 0)
   else:
     set_cparm("RADIATION", 0)
     set_cparm("RAD_NUM_TYPES", 0)
@@ -506,6 +513,13 @@ def build(PROBLEM, PATHS):
     set_rparm('phibin', 'int', default = 8);
     if util.parm_is_active(CPARMS, 'FLATEMISS'):
       set_rparm('cnu_flat', 'double', default = 1.)
+    if util.parm_is_active(CPARMS, "RZ_HISTOGRAMS"):
+      if CPARMS['METRIC'] == 'MINKOWSKI':
+        set_rparm('rz_rmax', 'double', default = 1)
+        set_rparm('rz_zmax', 'double', default = 1)
+      if CPARMS['METRIC'] == 'MKS':
+        set_rparm('rz_rmax', 'double', default = 40)
+        set_rparm('rz_zmax', 'double', default = 40)
     
   set_rparm('init_from_grmhd', 'string', default = 'No')
   


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add new charged-current neutrino interactions.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

- Fixes the survival probability formula to properly use the shallow area divided by the deep area.
- Adds histograms to the output that accumulate the cylindrical radius and distance from the equator of the origin of superphotons
- Adds a flag to track whether or not a given superphoton has oscillated

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.

