### PR TITLE
Minor functional support for 2D dumps in hdf5_to_dict.py and movie.py

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
             make -s install
         - name: Cache Python
           id: pycache
-          uses: actions/cache@v2
+          uses: actions/cache@v4
           env:
             cache-name: miniconda
           with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
             sudo apt-get install -y --force-yes -qq libmpich-dev libgsl0-dbg libgsl0-dev
         - name: Cache HDF5
           id: h5cache
-          uses: actions/cache@v2
+          uses: actions/cache@v4
           env:
             cache-name: hdf5-1.8.21-parallel
           with:

--- a/script/analysis/hdf5_to_dict.py
+++ b/script/analysis/hdf5_to_dict.py
@@ -494,12 +494,15 @@ def load_sadw(fname):
         d[k] = v[()]
   return t,sadw,sph,zoh
 
-def load_diag(path, hdr = None, nulegacy = False, timers = True):
+def load_diag(path, hdr = None, nulegacy = False, timers = True, twod = False):
   import numpy as np
 
   # load header
   if hdr is None:
-    dfiles = sorted(glob.glob(os.path.join(path,'dump_*.h5')))
+    if twod:
+      dfiles = sorted(glob.glob(os.path.join(path,'dump2d_*.h5')))
+    else:
+      dfiles = sorted(glob.glob(os.path.join(path,'dump_*.h5')))
     if len(dfiles) < 1:
       import util
       util.warn("Cannot read header. No dumps available.")

--- a/script/analysis/movie.py
+++ b/script/analysis/movie.py
@@ -61,6 +61,11 @@ parser.add_argument('--nproc',
                     type=int,
                     help=('Number of parallel processe to use. '
                           +'If not set, defaults to all available cores.'))
+parser.add_argument('--twod',
+                    dest='twod',
+                    default=False,
+                    action='store_true',
+                    help=('For 2d dump files'))
 
 
 args = parser.parse_args()
@@ -79,7 +84,7 @@ else:
   util.safe_remove(tmpdir)
   os.mkdir(tmpdir)
 
-dfnams = io.get_dumps_full(dfold)
+dfnams = io.get_dumps_full(dfold, twod=args.twod)
 hdr = io.load_hdr(dfnams[0])
 geom = io.load_geom(hdr)
 num_files = len(dfnams)


### PR DESCRIPTION
## PR Summary

`hdf5_to_dict.py`: added minor support for 2D dumps files in the `load_diag` function if a header is not provided
`movie.py`: added minor support for generating movies from 2D dumps files

