### PR TITLE
[WIP] Add Kumamoto B field dependent neutrino opacities

### DIFF
--- a/core/input.c
+++ b/core/input.c
@@ -158,6 +158,10 @@ void set_core_params() {
 #if HDF5_OPACITIES
   set_param("opac_file", &opac_file);
 #endif // HDF5_OPACITIES
+#if KUMAMOTO_OPACITIES
+  printf("Trying to use Kumamoto opacities! These are not currently implemented, crashing out...\n");
+  exit(-1);
+#endif // KUMAMOTO_OPACITIES
 #endif // RADTYPE_NEUTRINOS
 #endif // RADIATION
 

--- a/prob/torus_cbc/build.py
+++ b/prob/torus_cbc/build.py
@@ -40,6 +40,7 @@ SMALL = '-small' in sys.argv or NOB
 TRACERTEST = '-tracertest' in sys.argv
 RESTARTTEST = '-restarttest' in sys.argv
 HDF = '-hdf' in sys.argv
+KUMAMOTO = '-kumamoto' in sys.argv
 OSCILLATIONS = "-oscillations" in sys.argv
 N1N2N3CPU_FROM_CLI = '-n1n2n3cpu' in sys.argv
 N1N2N3TOT_FROM_CLI = '-n1n2n3tot' in sys.argv
@@ -71,7 +72,7 @@ N3TOT_FROM_CLI = '-n3tot' in sys.argv
 EMISS = not NOEMISS
 SCATT = not (NOSCATT or KILL)
 ABS = not (NOABS or KILL)
-FORTRAN = NEUTRINOS and not HDF
+FORTRAN = NEUTRINOS and not HDF and not KUMAMOTO
 TRACERS = not NOTRACE
 
 USE_TABLE = GAMTABLE or RELTABLE
@@ -411,6 +412,7 @@ if KILL:
     bhl.config.set_cparm('KILL_ALL_PACKETS', True)
 bhl.config.set_cparm('BURROWS_OPACITIES', FORTRAN)
 bhl.config.set_cparm('HDF5_OPACITIES', HDF)
+bhl.config.set_cparm('KUMAMOTO_OPACITIES',KUMAMOTO)
 bhl.config.set_cparm('NU_BINS', 61)
 bhl.config.set_cparm('ESTIMATE_THETAE', False)
 bhl.config.set_cparm('GRAYABSORPTION',  False)

--- a/script/config.py
+++ b/script/config.py
@@ -337,6 +337,10 @@ def build(PROBLEM, PATHS):
       print_config("HDF5_OPACITIES", CPARMS["HDF5_OPACITIES"])
     else:
       set_cparm("HDF5_OPACITIES", 0)
+    if util.parm_is_active(CPARMS, "KUMAMOTO_OPACITIES"):
+      print_config("KUMAMOTO_OPACITIES", CPARMS["KUMAMOTO_OPACITIES"])
+    else:
+      set_cparm("KUMAMOTO_OPACITIES", 0)
     if util.parm_is_active(CPARMS, "RAD_NUM_TYPES"):
       print_config("RAD_NUM_TYPES", CPARMS["RAD_NUM_TYPES"])
     else:


### PR DESCRIPTION
## PR Summary
Currently WIP and massively unfinished.

This PR implements (eventually) the magnetic field dependent neutrino opacities of Kumamoto [citation tbd]. Currently we can select at build time `-kumamoto` and we (should) skip the two existing opacity models. 

Currently just complains and exits.

## PR Checklist

- [ ] Adds a test for any bugs fixed. Adds tests for new features.

